### PR TITLE
Telephony: reload CarrierConfig based on changes to build display ver…

### DIFF
--- a/src/com/android/phone/CarrierConfigLoader.java
+++ b/src/com/android/phone/CarrierConfigLoader.java
@@ -345,11 +345,11 @@ public class CarrierConfigLoader extends ICarrierConfigLoader.Stub {
                     SharedPreferences sharedPrefs =
                             PreferenceManager.getDefaultSharedPreferences(mContext);
                     final String lastFingerprint = sharedPrefs.getString(KEY_FINGERPRINT, null);
-                    if (!Build.FINGERPRINT.equals(lastFingerprint)) {
+                    if (!Build.DISPLAY.equals(lastFingerprint)) {
                         log("Build fingerprint changed. old: "
-                                + lastFingerprint + " new: " + Build.FINGERPRINT);
+                                + lastFingerprint + " new: " + Build.DISPLAY);
                         clearCachedConfigForPackage(null);
-                        sharedPrefs.edit().putString(KEY_FINGERPRINT, Build.FINGERPRINT).apply();
+                        sharedPrefs.edit().putString(KEY_FINGERPRINT, Build.DISPLAY).apply();
                     }
                     break;
             }


### PR DESCRIPTION
…sion

CyanogenMod devices tend to override the build fingerprint with a value
from a shipped stock ROM, which means this check will never change even
if the user flashes a new nightly

Change-Id: Ic29cb9587f099087c5870f5e8c501dfc1d0a5478